### PR TITLE
Added github workflow to build and publish docker files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: shellcheck
-        run: shellcheck nextcloud/rootfs/usr/bin/run.sh
+    #   - name: shellcheck
+    #     run: shellcheck nextcloud/rootfs/usr/bin/run.sh
       - name: build docker files
         run: docker run --rm --privileged	-v /var/run/docker.sock:/var/run/docker.sock -v ~/.docker:/root/.docker -v "$(pwd)":/data homeassistant/amd64-builder	-t nextcloud	--all	--test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     #   - name: shellcheck
     #     run: shellcheck nextcloud/rootfs/usr/bin/run.sh
       - name: build docker files
-        run: docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -v ~/.docker:/root/.docker -v "$(pwd)":/data homeassistant/amd64-builder	-t nextcloud --all --test
+        run: docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -v ~/.docker:/root/.docker -v "$(pwd)":/data homeassistant/amd64-builder	-t nextcloud --amd64 --test
       - name: publish docker files
         if: github.event_name != 'pull_request'
-        run: docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -v ~/.docker:/root/.docker -v "$(pwd)":/data homeassistant/amd64-builder	-t nextcloud --all --release-tag --docker-user sabuto --docker-password ${{ secrets.DOCKER_PASSWORD }}
+        run: docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -v ~/.docker:/root/.docker -v "$(pwd)":/data homeassistant/amd64-builder	-t nextcloud --amd64 --release-tag --docker-user sabuto --docker-password ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,4 +13,4 @@ jobs:
     #   - name: shellcheck
     #     run: shellcheck nextcloud/rootfs/usr/bin/run.sh
       - name: build docker files
-        run: docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -v ~/.docker:/root/.docker -v "$(pwd)":/data homeassistant/amd64-builder	--target nextcloud --all --test
+        run: docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -v ~/.docker:/root/.docker -v "$(pwd)":/data homeassistant/amd64-builder	-t nextcloud --amd64 --test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,4 +13,7 @@ jobs:
     #   - name: shellcheck
     #     run: shellcheck nextcloud/rootfs/usr/bin/run.sh
       - name: build docker files
-        run: docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -v ~/.docker:/root/.docker -v "$(pwd)":/data homeassistant/amd64-builder	-t nextcloud --amd64 --test
+        run: docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -v ~/.docker:/root/.docker -v "$(pwd)":/data homeassistant/amd64-builder	-t nextcloud --all --test
+      - name: publish docker files
+        if: github.event_name != 'pull_request'
+        run: docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -v ~/.docker:/root/.docker -v "$(pwd)":/data homeassistant/amd64-builder	-t nextcloud --all --release-tag --docker-user sabuto --docker-password ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,4 +13,4 @@ jobs:
     #   - name: shellcheck
     #     run: shellcheck nextcloud/rootfs/usr/bin/run.sh
       - name: build docker files
-        run: docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -v ~/.docker:/root/.docker -v "$(pwd)":/data homeassistant/amd64-builder	-t nextcloud --all --test
+        run: docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -v ~/.docker:/root/.docker -v "$(pwd)":/data homeassistant/amd64-builder	-t /nextcloud --all --test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,4 +13,4 @@ jobs:
     #   - name: shellcheck
     #     run: shellcheck nextcloud/rootfs/usr/bin/run.sh
       - name: build docker files
-        run: docker run --rm --privileged	-v /var/run/docker.sock:/var/run/docker.sock -v ~/.docker:/root/.docker -v "$(pwd)":/data homeassistant/amd64-builder	-t nextcloud	--all	--test
+        run: docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -v ~/.docker:/root/.docker -v "$(pwd)":/data homeassistant/amd64-builder	-t nextcloud --all --test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,4 +15,6 @@ jobs:
       # - name: build docker files
         # run: docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -v ~/.docker:/root/.docker -v "$(pwd)":/data homeassistant/amd64-builder	-t nextcloud --all --test
       - name: pwd
-        run: echo pwd
+        run: |
+          pwd
+          ls -la

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,5 +12,7 @@ jobs:
       - uses: actions/checkout@v1
     #   - name: shellcheck
     #     run: shellcheck nextcloud/rootfs/usr/bin/run.sh
-      - name: build docker files
-        run: docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -v ~/.docker:/root/.docker -v "$(pwd)":/data homeassistant/amd64-builder	-t /nextcloud/nextcloud --all --test
+      # - name: build docker files
+        # run: docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -v ~/.docker:/root/.docker -v "$(pwd)":/data homeassistant/amd64-builder	-t nextcloud --all --test
+      - name: pwd
+        run: echo pwd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,11 +12,5 @@ jobs:
       - uses: actions/checkout@v1
     #   - name: shellcheck
     #     run: shellcheck nextcloud/rootfs/usr/bin/run.sh
-      # - name: build docker files
-        # run: docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -v ~/.docker:/root/.docker -v "$(pwd)":/data homeassistant/amd64-builder	-t nextcloud --all --test
-      - name: pwd
-        run: |
-          pwd
-          ls -la
-          cd nextcloud
-          ls -la
+      - name: build docker files
+        run: docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -v ~/.docker:/root/.docker -v "$(pwd)":/data homeassistant/amd64-builder	--target nextcloud --all --test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,3 +18,5 @@ jobs:
         run: |
           pwd
           ls -la
+          cd nextcloud
+          ls -la

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,4 +13,4 @@ jobs:
     #   - name: shellcheck
     #     run: shellcheck nextcloud/rootfs/usr/bin/run.sh
       - name: build docker files
-        run: docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -v ~/.docker:/root/.docker -v "$(pwd)":/data homeassistant/amd64-builder	-t /nextcloud --all --test
+        run: docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -v ~/.docker:/root/.docker -v "$(pwd)":/data homeassistant/amd64-builder	-t /nextcloud/nextcloud --all --test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,16 @@
+name: Docker build and shellcheck
+
+on: [push, pull_request]
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: shellcheck
+        run: shellcheck nextcloud/rootfs/usr/bin/run.sh
+      - name: build docker files
+        run: docker run --rm --privileged	-v /var/run/docker.sock:/var/run/docker.sock -v ~/.docker:/root/.docker -v "$(pwd)":/data homeassistant/amd64-builder	-t nextcloud	--all	--test

--- a/nextcloud/config.json
+++ b/nextcloud/config.json
@@ -33,5 +33,6 @@
         "amd64",
         "armhf",
         "i386"
-    ]
+    ],
+    "image": "sabuto/{arch}-nextcloud"
 }

--- a/nextcloud/config.json
+++ b/nextcloud/config.json
@@ -1,6 +1,6 @@
 {
     "name": "Nextcloud",
-    "version": "dev",
+    "version": "18.0.4",
     "slug": "nextcloud",
     "description": "Nextcloud addon. Image based on upstream docker images. This is just a wrapper to pass environment variable to the container.",
     "url": "https://github.com/mtthp/hassio-addons/tree/master/nextcloud",

--- a/nextcloud/config.json
+++ b/nextcloud/config.json
@@ -1,6 +1,6 @@
 {
     "name": "Nextcloud",
-    "version": "18.0.4",
+    "version": "dev",
     "slug": "nextcloud",
     "description": "Nextcloud addon. Image based on upstream docker images. This is just a wrapper to pass environment variable to the container.",
     "url": "https://github.com/mtthp/hassio-addons/tree/master/nextcloud",


### PR DESCRIPTION
This will build the docker images using the hassio builder. At the moment it is only set to build the amd64 image but you can build others too. The first builds to make sure there is no errors. The second will rebuild and publish. Make sure you change the docker username for yours and add a secret for the password to the repo. I have also included a shellcheck but i have commented this out for now as i dont have time to run through the errors. The build will run for commits and PR's where as the publish on runs for commits. If the build job fails the whole process is stopped so it doesn't publish faulty files. Sorry for the messy commits, if i was you i would squash and merge so there is only one commit in the history :). On my repo's i have it so it only publishes the files to Dockerhub when i do a release but as far as i can see you don't do releases so this is why i have done it this way. Any questions let me know.